### PR TITLE
There is no reason to add long delays for dev

### DIFF
--- a/config/environments/development.json
+++ b/config/environments/development.json
@@ -10,5 +10,5 @@
     "DOCKER_HUB_SEARCH_URL": "/api/docker/hub/v1/search",
     "NUMBER_OF_ITEMS_PER_PAGE": 20,
     "NUMBER_OF_DISPLAYED_PAGES": 5,
-    "TIMEOUT": 3000
+    "TIMEOUT": 0
 }


### PR DESCRIPTION
It takes a long time to load pods and replication controllers in the development mode due to 3000ms timeouts. This timeout can be reduced to 0 for development.

On a related note: Why are timeouts used in the services? This should not be necessary.
